### PR TITLE
Support histogram, flush on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.3.0
+----
+* timing!() and value!() metrics types now use a histogram, which enables
+percentiles in CloudWatch. However this could lead to more API calls, if there
+are many unique values. See Limitations in the README.
+* The builder now takes a shutdown Future, which enables flush of metrics on
+shutdown.
+
 0.2.0
 -----
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,9 @@ log = "0.4.8"
 metrics = { version = "0.12.1", features = ["std"] }
 rusoto_cloudwatch = "0.43.0-beta.1"
 rusoto_core = "0.43.0-beta.1"
+stream-cancel = "0.5.2"
 tokio = { version = "0.2.11", features = ["full"] }
+
+[dev-dependencies]
+async-trait = "0.1.24"
+tokio = { version = "0.2.11", features = ["full", "test-util"] }

--- a/README.md
+++ b/README.md
@@ -33,3 +33,14 @@ fn main() {
     metrics::counter!("requests", 1);
 }
 ```
+
+Limitations
+-----------
+
+The CloudWatch metrics API imposes some limitations.
+
+* Max 10 labels (dimensions) per metric
+* Max 150 unique histogram values (used by `timing!()` and `value!()`) per API
+call. Going beyond this works but will incur one API call per batch of 150
+unique values. Could be a good idea to measure timing in milliseconds rather
+than nanoseconds, to keep down the number of unique values.

--- a/clippy.sh
+++ b/clippy.sh
@@ -3,4 +3,5 @@
 cargo clippy -- \
   --deny warnings \
   --allow clippy::new_without_default \
+  --allow clippy::unneeded-field-pattern \
   --allow clippy::unit_arg

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,23 +1,38 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, fmt};
 
 use crate::{
-    collector::{self, Config, Resolution},
+    collector::{self, ClientBuilder, Config, Resolution},
     error::Error,
 };
 
-pub use rusoto_core::Region;
+use rusoto_cloudwatch::CloudWatchClient;
+pub use {rusoto_cloudwatch::CloudWatch, rusoto_core::Region};
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct Builder {
     cloudwatch_namespace: Option<String>,
     default_dimensions: BTreeMap<String, String>,
     storage_resolution: Option<Resolution>,
     send_interval_secs: Option<u64>,
     region: Option<Region>,
+    client_builder: Option<ClientBuilder>,
 }
 
 pub fn builder() -> Builder {
     Builder::default()
+}
+
+fn default_client_builder() -> ClientBuilder {
+    Box::new(|region| Box::new(CloudWatchClient::new(region)))
+}
+
+fn extract_namespace(cloudwatch_namespace: Option<String>) -> Result<String, Error> {
+    match cloudwatch_namespace {
+        Some(namespace) if !namespace.is_empty() => Ok(namespace),
+        _ => Err(Error::BuilderIncomplete(
+            "cloudwatch_namespace missing".into(),
+        )),
+    }
 }
 
 impl Builder {
@@ -60,6 +75,13 @@ impl Builder {
         }
     }
 
+    pub fn client_builder(self, client_builder: ClientBuilder) -> Self {
+        Self {
+            client_builder: Some(client_builder),
+            ..self
+        }
+    }
+
     /// Initializes the CloudWatch metrics backend and runs it in a new thread
     pub fn init_thread(self) -> Result<(), Error> {
         collector::init(self.build_config()?);
@@ -78,15 +100,28 @@ impl Builder {
             storage_resolution: self.storage_resolution.unwrap_or(Resolution::Minute),
             send_interval_secs: self.send_interval_secs.unwrap_or(10),
             region: self.region.unwrap_or(Region::UsEast1),
+            client_builder: self.client_builder.unwrap_or_else(default_client_builder),
         })
     }
 }
 
-fn extract_namespace(cloudwatch_namespace: Option<String>) -> Result<String, Error> {
-    match cloudwatch_namespace {
-        Some(namespace) if !namespace.is_empty() => Ok(namespace),
-        _ => Err(Error::BuilderIncomplete(
-            "cloudwatch_namespace missing".into(),
-        )),
+impl fmt::Debug for Builder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            cloudwatch_namespace,
+            default_dimensions,
+            storage_resolution,
+            send_interval_secs,
+            region,
+            client_builder: _,
+        } = self;
+        f.debug_struct("Builder")
+            .field("cloudwatch_namespace", cloudwatch_namespace)
+            .field("default_dimensions", default_dimensions)
+            .field("storage_resolution", storage_resolution)
+            .field("send_interval_secs", send_interval_secs)
+            .field("region", region)
+            .field("client_builder", &"<Fn(Region) -> Box<dyn CloudWatch>")
+            .finish()
     }
 }

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -126,6 +126,8 @@ pub async fn init_future(config: Config) -> Result<(), Error> {
         while let Some(msg) = message_stream.next().await {
             collector.accept(msg);
         }
+        // Need to drop this before flushing or we deadlock on shutdown
+        drop(message_stream);
         // Send a final flush on shutdown
         collector.accept(Message::SendBatch {
             send_all_before: std::u64::MAX,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,18 @@
 #![warn(rust_2018_idioms)]
 #![forbid(unsafe_code)]
 
-pub use builder::{builder, Builder};
-pub use error::Error;
+pub use {rusoto_cloudwatch::CloudWatch, rusoto_core::Region};
+
+pub use {
+    builder::{builder, Builder},
+    collector::Resolution,
+    error::Error,
+};
+
+use std::{future::Future, pin::Pin};
 
 mod builder;
 mod collector;
 mod error;
+
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + Sync + 'a>>;

--- a/tests/common/mock.rs
+++ b/tests/common/mock.rs
@@ -1,0 +1,221 @@
+#![allow(unused)]
+use std::sync::Arc;
+
+use {
+    async_trait::async_trait,
+    rusoto_cloudwatch::*,
+    rusoto_core::{RusotoError, RusotoFuture},
+    tokio::sync::Mutex,
+};
+
+#[derive(Clone, Default)]
+pub struct MockCloudWatchClient {
+    pub put_metric_data: Arc<Mutex<Vec<PutMetricDataInput>>>,
+}
+
+#[async_trait]
+impl CloudWatch for MockCloudWatchClient {
+    async fn delete_alarms(
+        &self,
+        input: DeleteAlarmsInput,
+    ) -> Result<(), RusotoError<DeleteAlarmsError>> {
+        todo!()
+    }
+
+    async fn delete_anomaly_detector(
+        &self,
+        input: DeleteAnomalyDetectorInput,
+    ) -> Result<DeleteAnomalyDetectorOutput, RusotoError<DeleteAnomalyDetectorError>> {
+        todo!()
+    }
+
+    async fn delete_dashboards(
+        &self,
+        input: DeleteDashboardsInput,
+    ) -> Result<DeleteDashboardsOutput, RusotoError<DeleteDashboardsError>> {
+        todo!()
+    }
+
+    async fn delete_insight_rules(
+        &self,
+        input: DeleteInsightRulesInput,
+    ) -> Result<DeleteInsightRulesOutput, RusotoError<DeleteInsightRulesError>> {
+        todo!()
+    }
+
+    async fn describe_alarm_history(
+        &self,
+        input: DescribeAlarmHistoryInput,
+    ) -> Result<DescribeAlarmHistoryOutput, RusotoError<DescribeAlarmHistoryError>> {
+        todo!()
+    }
+
+    async fn describe_alarms(
+        &self,
+        input: DescribeAlarmsInput,
+    ) -> Result<DescribeAlarmsOutput, RusotoError<DescribeAlarmsError>> {
+        todo!()
+    }
+
+    async fn describe_alarms_for_metric(
+        &self,
+        input: DescribeAlarmsForMetricInput,
+    ) -> Result<DescribeAlarmsForMetricOutput, RusotoError<DescribeAlarmsForMetricError>> {
+        todo!()
+    }
+
+    async fn describe_anomaly_detectors(
+        &self,
+        input: DescribeAnomalyDetectorsInput,
+    ) -> Result<DescribeAnomalyDetectorsOutput, RusotoError<DescribeAnomalyDetectorsError>> {
+        todo!()
+    }
+
+    async fn describe_insight_rules(
+        &self,
+        input: DescribeInsightRulesInput,
+    ) -> Result<DescribeInsightRulesOutput, RusotoError<DescribeInsightRulesError>> {
+        todo!()
+    }
+
+    async fn disable_alarm_actions(
+        &self,
+        input: DisableAlarmActionsInput,
+    ) -> Result<(), RusotoError<DisableAlarmActionsError>> {
+        todo!()
+    }
+
+    async fn disable_insight_rules(
+        &self,
+        input: DisableInsightRulesInput,
+    ) -> Result<DisableInsightRulesOutput, RusotoError<DisableInsightRulesError>> {
+        todo!()
+    }
+
+    async fn enable_alarm_actions(
+        &self,
+        input: EnableAlarmActionsInput,
+    ) -> Result<(), RusotoError<EnableAlarmActionsError>> {
+        todo!()
+    }
+
+    async fn enable_insight_rules(
+        &self,
+        input: EnableInsightRulesInput,
+    ) -> Result<EnableInsightRulesOutput, RusotoError<EnableInsightRulesError>> {
+        todo!()
+    }
+
+    async fn get_dashboard(
+        &self,
+        input: GetDashboardInput,
+    ) -> Result<GetDashboardOutput, RusotoError<GetDashboardError>> {
+        todo!()
+    }
+
+    async fn get_insight_rule_report(
+        &self,
+        input: GetInsightRuleReportInput,
+    ) -> Result<GetInsightRuleReportOutput, RusotoError<GetInsightRuleReportError>> {
+        todo!()
+    }
+
+    async fn get_metric_data(
+        &self,
+        input: GetMetricDataInput,
+    ) -> Result<GetMetricDataOutput, RusotoError<GetMetricDataError>> {
+        todo!()
+    }
+
+    async fn get_metric_statistics(
+        &self,
+        input: GetMetricStatisticsInput,
+    ) -> Result<GetMetricStatisticsOutput, RusotoError<GetMetricStatisticsError>> {
+        todo!()
+    }
+
+    async fn get_metric_widget_image(
+        &self,
+        input: GetMetricWidgetImageInput,
+    ) -> Result<GetMetricWidgetImageOutput, RusotoError<GetMetricWidgetImageError>> {
+        todo!()
+    }
+
+    async fn list_dashboards(
+        &self,
+        input: ListDashboardsInput,
+    ) -> Result<ListDashboardsOutput, RusotoError<ListDashboardsError>> {
+        todo!()
+    }
+
+    async fn list_metrics(
+        &self,
+        input: ListMetricsInput,
+    ) -> Result<ListMetricsOutput, RusotoError<ListMetricsError>> {
+        todo!()
+    }
+
+    async fn list_tags_for_resource(
+        &self,
+        input: ListTagsForResourceInput,
+    ) -> Result<ListTagsForResourceOutput, RusotoError<ListTagsForResourceError>> {
+        todo!()
+    }
+
+    async fn put_anomaly_detector(
+        &self,
+        input: PutAnomalyDetectorInput,
+    ) -> Result<PutAnomalyDetectorOutput, RusotoError<PutAnomalyDetectorError>> {
+        todo!()
+    }
+
+    async fn put_dashboard(
+        &self,
+        input: PutDashboardInput,
+    ) -> Result<PutDashboardOutput, RusotoError<PutDashboardError>> {
+        todo!()
+    }
+
+    async fn put_insight_rule(
+        &self,
+        input: PutInsightRuleInput,
+    ) -> Result<PutInsightRuleOutput, RusotoError<PutInsightRuleError>> {
+        todo!()
+    }
+
+    async fn put_metric_alarm(
+        &self,
+        input: PutMetricAlarmInput,
+    ) -> Result<(), RusotoError<PutMetricAlarmError>> {
+        todo!()
+    }
+
+    async fn put_metric_data(
+        &self,
+        input: PutMetricDataInput,
+    ) -> Result<(), RusotoError<PutMetricDataError>> {
+        self.put_metric_data.lock().await.push(input);
+        Ok(())
+    }
+
+    async fn set_alarm_state(
+        &self,
+        input: SetAlarmStateInput,
+    ) -> Result<(), RusotoError<SetAlarmStateError>> {
+        todo!()
+    }
+
+    async fn tag_resource(
+        &self,
+        input: TagResourceInput,
+    ) -> Result<TagResourceOutput, RusotoError<TagResourceError>> {
+        todo!()
+    }
+
+    async fn untag_resource(
+        &self,
+        input: UntagResourceInput,
+    ) -> Result<UntagResourceOutput, RusotoError<UntagResourceError>> {
+        todo!()
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,3 @@
+pub use mock::MockCloudWatchClient;
+
+mod mock;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,0 +1,54 @@
+use std::{error::Error, time::Duration};
+
+use futures::prelude::*;
+use rusoto_cloudwatch::CloudWatch;
+
+use common::MockCloudWatchClient;
+
+mod common;
+
+#[tokio::test]
+async fn test_flush_on_shutdown() -> Result<(), Box<dyn Error>> {
+    let client = MockCloudWatchClient::default();
+    let client_builder = {
+        let client = client.clone();
+        Box::new(move |_region| Box::new(client.clone()) as Box<dyn CloudWatch + Send + Sync>)
+    };
+
+    tokio::time::pause();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let backend_fut = Box::pin(
+        metrics_cloudwatch::builder()
+            .cloudwatch_namespace("test-ns")
+            .client_builder(client_builder)
+            .send_interval_secs(1)
+            .storage_resolution(metrics_cloudwatch::Resolution::Second)
+            .shutdown_signal(Box::pin(rx.map(|_| ())))
+            .init_future(),
+    );
+    let joinhandle = tokio::spawn(backend_fut);
+    tokio::time::advance(Duration::from_millis(5)).await;
+
+    for i in 0..150 {
+        metrics::value!("test", i);
+    }
+    metrics::value!("test", 0);
+    metrics::value!("test", 200);
+    tokio::time::advance(Duration::from_millis(5)).await;
+
+    // Send shutdown signal
+    tx.send(()).unwrap();
+    joinhandle.await??;
+
+    let actual = client.put_metric_data.lock().await;
+    assert_eq!(actual.len(), 2);
+
+    assert_eq!(actual[0].metric_data.len(), 1);
+    assert_eq!(actual[0].metric_data[0].counts.as_ref().unwrap().len(), 150);
+    assert_eq!(actual[0].metric_data[0].values.as_ref().unwrap().len(), 150);
+
+    assert_eq!(actual[1].metric_data.len(), 1);
+    assert_eq!(actual[1].metric_data[0].counts.as_ref().unwrap().len(), 1);
+    assert_eq!(actual[1].metric_data[0].values.as_ref().unwrap().len(), 1);
+    Ok(())
+}


### PR DESCRIPTION
* The builder now takes a shutdown Future, which enables flush of metrics on shutdown.
* Support for histograms is added, which means that we will see percentiles for timing!() and value!() metrics in CloudWatch. 