### PR TITLE
test: Add a benchmark for the metrics collector

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@v1
       - uses: icepuma/rust-action@master
         with:
-          args: cargo fmt -- --check && ./clippy.sh && cargo test
+          args: cargo fmt -- --check && ./clippy.sh && cargo test && cargo test --benches

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,10 @@ tokio = { version = "0.2.13", features = ["full"] }
 
 [dev-dependencies]
 async-trait = "0.1.24"
+criterion = "0.3"
 tokio = { version = "0.2.13", features = ["full", "test-util"] }
+
+
+[[bench]]
+name = "bench"
+harness = false

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,87 @@
+use {
+    criterion::{criterion_group, Benchmark, Criterion, Throughput},
+    futures::prelude::*,
+    metrics::Recorder,
+};
+
+use metrics_cloudwatch::collector;
+
+#[path = "../tests/common/mod.rs"]
+mod common;
+
+fn simple(c: &mut Criterion) {
+    const NUM_ENTRIES: usize = 2 * 1024;
+    c.bench(
+        "send_metrics",
+        Benchmark::new("full", |b| {
+            let mut runtime = tokio::runtime::Builder::new()
+                .basic_scheduler()
+                .enable_all()
+                .build()
+                .unwrap();
+            b.iter(|| {
+                runtime.block_on(async {
+                    let cloudwatch_client = common::MockCloudWatchClient::default();
+
+                    let (sender, receiver) = tokio::sync::oneshot::channel();
+                    let (recorder, task) = collector::new(collector::Config {
+                        cloudwatch_namespace: "".into(),
+                        default_dimensions: Default::default(),
+                        storage_resolution: collector::Resolution::Second,
+                        send_interval_secs: 200,
+                        region: rusoto_core::Region::UsEast1,
+                        client_builder: {
+                            let cloudwatch_client = cloudwatch_client.clone();
+                            Box::new(move |_| Box::new(cloudwatch_client.clone()))
+                        },
+                        shutdown_signal: receiver.map(|_| ()).boxed().shared(),
+                    });
+
+                    let task = tokio::spawn(task);
+
+                    for i in 0..NUM_ENTRIES {
+                        match i % 3 {
+                            0 => recorder.increment_counter("counter".into(), 1),
+                            1 => recorder.update_gauge("gauge".into(), i as i64 % 100),
+                            2 => recorder.record_histogram("histogram".into(), i as u64 % 10),
+                            _ => unreachable!(),
+                        }
+                        if i % 100 == 0 {
+                            // Give the emitter a chance to consume the entries we sent so that the
+                            // buffer does not fill up
+                            tokio::task::yield_now().await;
+                        }
+                    }
+
+                    tokio::task::yield_now().await;
+                    sender.send(()).unwrap();
+                    task.await.unwrap();
+
+                    let put_metric_data = cloudwatch_client.put_metric_data.lock().await;
+                    assert_eq!(
+                        put_metric_data
+                            .iter()
+                            .flat_map(|m| m.metric_data.iter())
+                            .filter(|data| data.metric_name == "counter")
+                            .map(|counter| counter.statistic_values.as_ref().unwrap().sample_count)
+                            .sum::<f64>(),
+                        (NUM_ENTRIES as f64 / 3.0).round(),
+                        "{:#?}",
+                        put_metric_data,
+                    );
+                });
+            });
+        })
+        .throughput(Throughput::Elements(NUM_ENTRIES as u64)),
+    );
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = simple
+}
+
+fn main() {
+    benches()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@ pub use {
 use std::{future::Future, pin::Pin};
 
 mod builder;
-mod collector;
+#[doc(hidden)]
+pub mod collector;
 mod error;
 
-pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + Sync + 'a>>;
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;


### PR DESCRIPTION
```
send_metrics/full       time:   [751.65 us 767.43 us 784.85 us]
                        thrpt:  [2.6094 Melem/s 2.6686 Melem/s 2.7247 Melem/s]
                 change:
                        time:   [+6.5227% +9.3539% +12.841%] (p = 0.00 < 0.05)
                        thrpt:  [-11.380% -8.5538% -6.1233%]
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe

```