### PR TITLE
feat: Report how many counts the metric instance received

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -345,7 +345,7 @@ impl Collector {
                         // value passed to each `increment_counter` call.
                         //
                         // In the case where we only increment by `1` each call the latter makes
-                        // in and max basically useless since the end result will leave both as `1`.
+                        // min and max basically useless since the end result will leave both as `1`.
                         // In the case where we sum the count first before calling
                         // `increment_counter` we do lose some granularity as the latter would give
                         // a spread in min/max.


### PR DESCRIPTION
 Instead of reporting the max and min of each `increment_counter`
request. Gives more information in the common case of sending counts
of 1 at the cost of not reporting the min and max value passed to
`increment_counter`.

In a perfectly orthogonal world a counter would not let us observe by
how much it was incremented with each time, but as long as we do we
should choose whatever is most useful. This makes increments observable
across metric collectors but not within them which should be more useful
since gauges can cover much of ground when wanting to observe min and
max in the same metric collector.

