### PR TITLE
feat: Improve the metric packing per put_metric_data call

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,12 @@ log = "0.4.8"
 metrics = { version = "0.12.1", features = ["std"] }
 rusoto_cloudwatch = "0.43.0"
 rusoto_core = "0.43.0"
+serde_json = "1"
 stream-cancel = "0.5.2"
 tokio = { version = "0.2.13", features = ["full"] }
 
 [dev-dependencies]
+proptest = "0.10"
 async-trait = "0.1.24"
 criterion = "0.3"
 tokio = { version = "0.2.13", features = ["full", "test-util"] }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -29,11 +29,7 @@ fn simple(c: &mut Criterion) {
                         default_dimensions: Default::default(),
                         storage_resolution: collector::Resolution::Second,
                         send_interval_secs: 200,
-                        region: rusoto_core::Region::UsEast1,
-                        client_builder: {
-                            let cloudwatch_client = cloudwatch_client.clone();
-                            Box::new(move |_| Box::new(cloudwatch_client.clone()))
-                        },
+                        client: Box::new(cloudwatch_client.clone()),
                         shutdown_signal: receiver.map(|_| ()).boxed().shared(),
                     });
 

--- a/proptest-regressions/collector.txt
+++ b/proptest-regressions/collector.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc f2f1f305bb977e8c11934e09f536b2dc0b4450310a485985363f918a71c452f6 # shrinks to metrics = [MetricDatum { counts: Some([0.0]), dimensions: Some([Dimension { name: "name", value: "value" }]), metric_name: "test", statistic_values: Some(StatisticSet { maximum: 0.0, minimum: 0.0, sample_count: 0.0, sum: 0.0 }), storage_resolution: Some(1), timestamp: Some("1970-01-01T00:00:00.000Z"), unit: Some("Count"), value: Some(1.0), values: Some([0.0]) }]

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -196,7 +196,7 @@ fn count_option_vec<T>(vs: &Option<Vec<T>>) -> usize {
     vs.as_ref().map(|vs| vs.len()).unwrap_or(0)
 }
 
-const MAX_CW_METRICS_PUT_SIZE: usize = 40_000;
+const MAX_CW_METRICS_PUT_SIZE: usize = 37_000; // Docs say 40k but we set our max lower to be safe since we only have a heuristic
 
 fn metrics_chunks(mut metrics: &[MetricDatum]) -> impl Iterator<Item = &[MetricDatum]> + '_ {
     std::iter::from_fn(move || {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -42,18 +42,31 @@ async fn test_flush_on_shutdown() -> Result<(), Box<dyn Error>> {
     joinhandle.await??;
 
     let actual = client.put_metric_data.lock().await;
-    assert_eq!(actual.len(), 3);
+    assert_eq!(actual.len(), 1);
 
-    assert_eq!(actual[0].metric_data.len(), 1);
-    assert_eq!(actual[0].metric_data[0].counts.as_ref().unwrap().len(), 150);
-    assert_eq!(actual[0].metric_data[0].values.as_ref().unwrap().len(), 150);
+    assert_eq!(actual[0].metric_data.len(), 3);
+    eprintln!("{:#?}", actual[0]);
+    let value_metric = actual[0]
+        .metric_data
+        .iter()
+        .find(|m| m.metric_name == "test" && m.counts.as_ref().unwrap().len() == 150)
+        .unwrap();
+    assert_eq!(value_metric.counts.as_ref().unwrap().len(), 150);
+    assert_eq!(value_metric.values.as_ref().unwrap().len(), 150);
 
-    assert_eq!(actual[1].metric_data.len(), 1);
-    assert_eq!(actual[1].metric_data[0].counts.as_ref().unwrap().len(), 1);
-    assert_eq!(actual[1].metric_data[0].values.as_ref().unwrap().len(), 1);
+    let count_metric = actual[0]
+        .metric_data
+        .iter()
+        .find(|m| m.metric_name == "test" && m.counts.as_ref().unwrap().len() == 1)
+        .unwrap();
+    assert_eq!(count_metric.counts.as_ref().unwrap().len(), 1);
+    assert_eq!(count_metric.values.as_ref().unwrap().len(), 1);
 
-    assert_eq!(actual[2].metric_data.len(), 1);
-    let count_data = &actual[2].metric_data[0];
+    let count_data = actual[0]
+        .metric_data
+        .iter()
+        .find(|m| m.metric_name == "count")
+        .unwrap();
     assert_eq!(
         count_data.statistic_values,
         Some(StatisticSet {


### PR DESCRIPTION
First is an explicit improvement but it does increase the risk of packing too many histograms together, causing the `put_metric_data` to overflow the 40Kb/request limit.

Second commit simplifies the client injection. I would like to enable gzip for the client since we can end up sending quite a bit of data and this would simplify it.