### PR TITLE
fix: Don't assume a default region/client

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -18,8 +18,8 @@ pub struct Builder {
     shutdown_signal: Option<BoxFuture<'static, ()>>,
 }
 
-pub fn builder(client: impl CloudWatch + Send + Sync + 'static) -> Builder {
-    Builder::new(client)
+pub fn builder(region: rusoto_core::Region) -> Builder {
+    Builder::new(region)
 }
 
 fn extract_namespace(cloudwatch_namespace: Option<String>) -> Result<String, Error> {
@@ -32,7 +32,11 @@ fn extract_namespace(cloudwatch_namespace: Option<String>) -> Result<String, Err
 }
 
 impl Builder {
-    pub fn new(client: impl CloudWatch + Send + Sync + 'static) -> Self {
+    pub fn new(region: rusoto_core::Region) -> Self {
+        Self::new_with(rusoto_cloudwatch::CloudWatchClient::new(region))
+    }
+
+    pub fn new_with(client: impl CloudWatch + Send + Sync + 'static) -> Self {
         Builder {
             cloudwatch_namespace: Default::default(),
             default_dimensions: Default::default(),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -14,7 +14,7 @@ async fn test_flush_on_shutdown() -> Result<(), Box<dyn Error>> {
     tokio::time::pause();
     let (tx, rx) = tokio::sync::oneshot::channel();
     let backend_fut = Box::pin(
-        metrics_cloudwatch::builder(client.clone())
+        metrics_cloudwatch::Builder::new_with(client.clone())
             .cloudwatch_namespace("test-ns")
             .send_interval_secs(1)
             .storage_resolution(metrics_cloudwatch::Resolution::Second)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -14,9 +14,8 @@ async fn test_flush_on_shutdown() -> Result<(), Box<dyn Error>> {
     tokio::time::pause();
     let (tx, rx) = tokio::sync::oneshot::channel();
     let backend_fut = Box::pin(
-        metrics_cloudwatch::builder()
+        metrics_cloudwatch::builder(client.clone())
             .cloudwatch_namespace("test-ns")
-            .client(Box::new(client.clone()))
             .send_interval_secs(1)
             .storage_resolution(metrics_cloudwatch::Resolution::Second)
             .shutdown_signal(Box::pin(rx.map(|_| ())))


### PR DESCRIPTION
Using `UsEast1` as the default region is different from
`Region::default()`, meaning that regardless of which default is
"better" it is still a point of confusion as long as they are different.

This avoids the question entirely by forcing users to supply the client
explicitly.