### PR TITLE
fix: Display averages for count metrics

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -59,7 +59,7 @@ fn simple(c: &mut Criterion) {
                             .iter()
                             .flat_map(|m| m.metric_data.iter())
                             .filter(|data| data.metric_name == "counter")
-                            .map(|counter| counter.statistic_values.as_ref().unwrap().sample_count)
+                            .map(|counter| counter.statistic_values.as_ref().unwrap().sum)
                             .sum::<f64>(),
                         (NUM_ENTRIES as f64 / 3.0).round(),
                         "{:#?}",

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -418,7 +418,10 @@ impl Collector {
                 if counter.sample_count > 0 {
                     let sum = counter.sum as f64;
                     let stats_set = StatisticSet {
-                        sample_count: counter.sample_count as f64,
+                        // We aren't interested in how many `counter!` calls we did so we put 1
+                        // here to allow cloudwatch to display the average between this and any
+                        // other instances posting to the same metric.
+                        sample_count: 1.0,
                         sum,
                         // Max and min for a count can either be the sum or the max/min of the
                         // value passed to each `increment_counter` call.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -66,7 +66,7 @@ async fn test_flush_on_shutdown() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         count_data.statistic_values,
         Some(StatisticSet {
-            sample_count: 150.0,
+            sample_count: 1.0,
             sum: 150.0,
             maximum: 150.0,
             minimum: 150.0


### PR DESCRIPTION
Using StatisticSet for count metrics in the current way causes the
average to always be 1 (since `sum / sample_count = 1`).

As we aren't really interested how many `counter!` calls we did we just
"group them together" into one per put_metric_data call.