### PR TITLE
feat: Add support for specifying cloudwatch units

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -485,12 +485,14 @@ impl Collector {
         Ok(())
     }
 
-    fn default_dimensions(&self) -> impl Iterator<Item = Dimension> {
+    fn default_dimensions(&self) -> impl Iterator<Item = Dimension> + '_ {
         self.config
             .default_dimensions
-            .clone()
-            .into_iter()
-            .map(|(name, value)| Dimension { name, value })
+            .iter()
+            .map(|(name, value)| Dimension {
+                name: name.to_owned(),
+                value: value.to_owned(),
+            })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub use {
     error::Error,
 };
 
-use std::{future::Future, pin::Pin};
+use std::{borrow::Cow, future::Future, pin::Pin};
 
 mod builder;
 #[doc(hidden)]
@@ -17,3 +17,75 @@ pub mod collector;
 mod error;
 
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+// From the CloudWatch docs:
+// Seconds | Microseconds | Milliseconds | Bytes | Kilobytes | Megabytes | Gigabytes | Terabytes | Bits | Kilobits | Megabits | Gigabits | Terabits | Percent | Count | Bytes/Second | Kilobytes/Second | Megabytes/Second | Gigabytes/Second | Terabytes/Second | Bits/Second | Kilobits/Second | Megabits/Second | Gigabits/Second | Terabits/Second | Count/Second | None
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum Unit {
+    Seconds,
+    Microseconds,
+    Milliseconds,
+    Bytes,
+    Kilobytes,
+    Megabytes,
+    Gigabytes,
+    Terabytes,
+    Bits,
+    Kilobits,
+    Megabits,
+    Gigabits,
+    Terabits,
+    Percent,
+    Count,
+    BytesPerSecond,
+    KilobytesPerSecond,
+    MegabytesPerSecond,
+    GigabytesPerSecond,
+    TerabytesPerSecond,
+    BitsPerSecond,
+    KilobitsPerSecond,
+    MegabitsPerSecond,
+    GigabitsPerSecond,
+    TerabitsPerSecond,
+    CountPerSecond,
+}
+
+impl Unit {
+    pub fn as_str(self) -> &'static str {
+        use self::Unit::*;
+        match self {
+            Seconds => "Seconds",
+            Microseconds => "Microseconds",
+            Milliseconds => "Milliseconds",
+            Bytes => "Bytes",
+            Kilobytes => "Kilobytes",
+            Megabytes => "Megabytes",
+            Gigabytes => "Gigabytes",
+            Terabytes => "Terabytes",
+            Bits => "Bits",
+            Kilobits => "Kilobits",
+            Megabits => "Megabits",
+            Gigabits => "Gigabits",
+            Terabits => "Terabits",
+            Percent => "Percent",
+            Count => "Count",
+            BytesPerSecond => "Bytes/Second",
+            KilobytesPerSecond => "Kilobytes/Second",
+            MegabytesPerSecond => "Megabytes/Second",
+            GigabytesPerSecond => "Gigabytes/Second",
+            TerabytesPerSecond => "Terabytes/Second",
+            BitsPerSecond => "Bits/Second",
+            KilobitsPerSecond => "Kilobits/Second",
+            MegabitsPerSecond => "Megabits/Second",
+            GigabitsPerSecond => "Gigabits/Second",
+            TerabitsPerSecond => "Terabits/Second",
+            CountPerSecond => "Count/Second",
+        }
+    }
+}
+
+impl From<Unit> for Cow<'static, str> {
+    fn from(unit: Unit) -> Self {
+        unit.as_str().into()
+    }
+}


### PR DESCRIPTION
Adds a special `@unit` label which is used to determine which unit to
store the metric under.

Not a perfect solution but we need some way to distinguish it from the
normal label => dimension usage.

