### PR TITLE
Amortize the cost of the timestamps

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -178,7 +178,9 @@ pub fn new(config: Config) -> (RecorderHandle, impl Future<Output = ()>) {
         RecorderHandle {
             sender: collect_sender,
         },
-        future::join(collection_fut, emitter.map(|_| ())).map(|_| ()),
+        async move {
+            futures_util::join!(collection_fut, emitter);
+        },
     )
 }
 

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -650,42 +650,42 @@ impl Collector {
 
 impl Recorder for RecorderHandle {
     fn register_counter(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
-        let _ = self.sender.clone().try_send(Datum {
+        let _ = self.sender.try_send(Datum {
             key,
             value: Value::Register { unit, description },
         });
     }
 
     fn register_gauge(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
-        let _ = self.sender.clone().try_send(Datum {
+        let _ = self.sender.try_send(Datum {
             key,
             value: Value::Register { unit, description },
         });
     }
 
     fn register_histogram(&self, key: Key, unit: Option<Unit>, description: Option<&'static str>) {
-        let _ = self.sender.clone().try_send(Datum {
+        let _ = self.sender.try_send(Datum {
             key,
             value: Value::Register { unit, description },
         });
     }
 
     fn increment_counter(&self, key: Key, value: u64) {
-        let _ = self.sender.clone().try_send(Datum {
+        let _ = self.sender.try_send(Datum {
             key,
             value: Value::Counter(value),
         });
     }
 
     fn update_gauge(&self, key: Key, value: GaugeValue) {
-        let _ = self.sender.clone().try_send(Datum {
+        let _ = self.sender.try_send(Datum {
             key,
             value: Value::Gauge(value),
         });
     }
 
     fn record_histogram(&self, key: Key, value: f64) {
-        let _ = self.sender.clone().try_send(Datum {
+        let _ = self.sender.try_send(Datum {
             key,
             value: Value::Histogram(HistogramValue::new(value).unwrap()),
         });


### PR DESCRIPTION
When we can read multiple datums in a short interval we do not need to retrieve the timestamp for every datum. Instead we can batch them to significantly cut the cost of this.