### PR TITLE
Fix the benchmark and some minor tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 
 [[package]]
 name = "cfg-if"
@@ -202,6 +213,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
+ "futures",
  "itertools 0.10.1",
  "lazy_static",
  "num-traits",
@@ -214,6 +226,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -586,9 +599,9 @@ checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.9"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d6baa1b441335f3ce5098ac421fb6547c46dda735ca1bc6d0153c838f9dd83"
+checksum = "7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -689,9 +702,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "log"
@@ -763,6 +776,7 @@ dependencies = [
 name = "metrics_cloudwatch"
 version = "0.14.1-alpha.0"
 dependencies = [
+ "ahash",
  "async-trait",
  "chrono",
  "criterion",
@@ -909,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "2.5.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f100fcfb41e5385e0991f74981732049f9b896821542a219420491046baafdc2"
+checksum = "039f02eb0f69271f26abe3202189275d7aa2258b903cb0281b5de710a2570ff3"
 dependencies = [
  "num-traits",
 ]
@@ -1505,9 +1519,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "subtle"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -1577,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570c2eb13b3ab38208130eccd41be92520388791207fde783bda7c1e8ace28d4"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1596,9 +1610,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["metrics", "cloudwatch", "aws"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+ahash = "0.7"
 chrono = "0.4.13"
 futures-util = { version = "0.3.5", default-features = false }
 log = "0.4.11"
@@ -29,7 +30,7 @@ tokio = { version = "1", features = ["sync", "time"] }
 [dev-dependencies]
 proptest = "1"
 async-trait = "0.1.24"
-criterion = "0.3"
+criterion = { version = "0.3", features = ["async_tokio"] }
 tokio = { version = "1", features = ["test-util"] }
 
 [features]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -13,66 +13,64 @@ fn simple(c: &mut Criterion) {
     const NUM_ENTRIES: usize = 2 * 1024;
     let mut group = c.benchmark_group("send_metrics");
 
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
     group
         .bench_function("full", |b| {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap();
-            b.iter(|| {
-                runtime.block_on(async {
-                    let cloudwatch_client = common::MockCloudWatchClient::default();
+            b.to_async(&runtime).iter(|| async {
+                let cloudwatch_client = common::MockCloudWatchClient::default();
 
-                    let (sender, receiver) = tokio::sync::oneshot::channel();
-                    let (recorder, task) = collector::new(collector::Config {
-                        cloudwatch_namespace: "".into(),
-                        default_dimensions: Default::default(),
-                        storage_resolution: collector::Resolution::Second,
-                        send_interval_secs: 200,
-                        client: Box::new(cloudwatch_client.clone()),
-                        shutdown_signal: receiver.map(|_| ()).boxed().shared(),
-                        metric_buffer_size: 1024,
-                    });
-
-                    let task = tokio::spawn(task);
-
-                    for i in 0..NUM_ENTRIES {
-                        match i % 3 {
-                            0 => recorder.increment_counter(&metrics::Key::from("counter"), 1),
-                            1 => recorder.update_gauge(
-                                &metrics::Key::from("gauge"),
-                                metrics::GaugeValue::Absolute((i as i64 % 100) as f64),
-                            ),
-                            2 => recorder.record_histogram(
-                                &metrics::Key::from("histogram"),
-                                (i as u64 % 10) as f64,
-                            ),
-                            _ => unreachable!(),
-                        }
-                        if i % 100 == 0 {
-                            // Give the emitter a chance to consume the entries we sent so that the
-                            // buffer does not fill up
-                            tokio::task::yield_now().await;
-                        }
-                    }
-
-                    tokio::task::yield_now().await;
-                    sender.send(()).unwrap();
-                    task.await.unwrap();
-
-                    let put_metric_data = cloudwatch_client.put_metric_data.lock().await;
-                    assert_eq!(
-                        put_metric_data
-                            .iter()
-                            .flat_map(|m| m.metric_data.iter())
-                            .filter(|data| data.metric_name == "counter")
-                            .map(|counter| counter.statistic_values.as_ref().unwrap().sum)
-                            .sum::<f64>(),
-                        (NUM_ENTRIES as f64 / 3.0).round(),
-                        "{:#?}",
-                        put_metric_data,
-                    );
+                let (shutdown_sender, receiver) = tokio::sync::oneshot::channel();
+                let (recorder, task) = collector::new(collector::Config {
+                    cloudwatch_namespace: "".into(),
+                    default_dimensions: Default::default(),
+                    storage_resolution: collector::Resolution::Second,
+                    send_interval_secs: 200,
+                    client: Box::new(cloudwatch_client.clone()),
+                    shutdown_signal: receiver.map(|_| ()).boxed().shared(),
+                    metric_buffer_size: 1024,
                 });
+
+                let task = tokio::spawn(task);
+
+                for i in 0..NUM_ENTRIES {
+                    match i % 3 {
+                        0 => recorder.increment_counter(&metrics::Key::from("counter"), 1),
+                        1 => recorder.update_gauge(
+                            &metrics::Key::from("gauge"),
+                            metrics::GaugeValue::Absolute((i as i64 % 100) as f64),
+                        ),
+                        2 => recorder.record_histogram(
+                            &metrics::Key::from("histogram"),
+                            (i as u64 % 10) as f64,
+                        ),
+                        _ => unreachable!(),
+                    }
+                    if i % 100 == 0 {
+                        // Give the emitter a chance to consume the entries we sent so that the
+                        // buffer does not fill up
+                        tokio::task::yield_now().await;
+                    }
+                }
+
+                tokio::task::yield_now().await;
+                shutdown_sender.send(()).unwrap();
+                task.await.unwrap();
+
+                let put_metric_data = cloudwatch_client.put_metric_data.lock().await;
+                assert_eq!(
+                    put_metric_data
+                        .iter()
+                        .flat_map(|m| m.metric_data.iter())
+                        .filter(|data| data.metric_name == "counter")
+                        .map(|counter| counter.statistic_values.as_ref().unwrap().sum)
+                        .sum::<f64>(),
+                    (NUM_ENTRIES as f64 / 3.0).round(),
+                    "{:#?}",
+                    put_metric_data,
+                );
             });
         })
         .throughput(Throughput::Elements(NUM_ENTRIES as u64));

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -31,7 +31,7 @@ type HashMap<K, V> = std::collections::HashMap<K, V, ahash::RandomState>;
 const MAX_CW_METRICS_PER_CALL: usize = 20;
 const MAX_CLOUDWATCH_DIMENSIONS: usize = 10;
 const MAX_HISTOGRAM_VALUES: usize = 150;
-const SEND_TIMEOUT: Duration = Duration::from_secs(2);
+const SEND_TIMEOUT: Duration = Duration::from_secs(4);
 
 pub struct Config {
     pub cloudwatch_namespace: String,

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::BTreeMap,
     convert::TryFrom,
     fmt,
     future::Future,
@@ -27,6 +27,7 @@ pub type ClientBuilder = Box<dyn Fn(Region) -> Box<dyn CloudWatch + Send + Sync>
 type Count = usize;
 type HistogramValue = ordered_float::NotNan<f64>;
 type Timestamp = u64;
+type HashMap<K, V> = std::collections::HashMap<K, V, ahash::RandomState>;
 
 const MAX_CW_METRICS_PER_CALL: usize = 20;
 const MAX_CLOUDWATCH_DIMENSIONS: usize = 10;
@@ -383,7 +384,7 @@ fn get_timeslot<'a>(
 ) -> &'a mut HashMap<Key, Aggregate> {
     metrics_data
         .entry(time_key(timestamp, config.storage_resolution))
-        .or_insert_with(HashMap::new)
+        .or_default()
 }
 
 fn accept_datum(


### PR DESCRIPTION
Reverts https://github.com/ramn/metrics_cloudwatch/pull/29 since it inevitably slows down shutdown which is problematic. An intermediary commit fixed the issue in the benchmarks but I think it is better to just not do it at all.