### PR TITLE
Changes API so that the AWS Cloudwatch client is supplied when starting the metrics. 

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -23,16 +23,18 @@ fn simple(c: &mut Criterion) {
                 let cloudwatch_client = common::MockCloudWatchClient::default();
 
                 let (shutdown_sender, receiver) = tokio::sync::oneshot::channel();
-                let (recorder, task) = collector::new(collector::Config {
-                    cloudwatch_namespace: "".into(),
-                    default_dimensions: Default::default(),
-                    storage_resolution: collector::Resolution::Second,
-                    send_interval_secs: 200,
-                    client: Box::new(cloudwatch_client.clone()),
-                    shutdown_signal: receiver.map(|_| ()).boxed().shared(),
-                    metric_buffer_size: 1024,
-                    force_flush_stream: Some(Box::pin(futures_util::stream::empty())),
-                });
+                let (recorder, task) = collector::new(
+                    cloudwatch_client.clone(),
+                    collector::Config {
+                        cloudwatch_namespace: "".into(),
+                        default_dimensions: Default::default(),
+                        storage_resolution: collector::Resolution::Second,
+                        send_interval_secs: 200,
+                        shutdown_signal: receiver.map(|_| ()).boxed().shared(),
+                        metric_buffer_size: 1024,
+                        force_flush_stream: Some(Box::pin(futures_util::stream::empty())),
+                    },
+                );
 
                 let task = tokio::spawn(task);
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -18,13 +18,13 @@ async fn test_flush_on_shutdown() -> Result<(), Box<dyn Error>> {
     tokio::time::pause();
     let (tx, rx) = tokio::sync::oneshot::channel();
     let backend_fut = Box::pin(
-        metrics_cloudwatch::Builder::new_with_client(client.clone())
+        metrics_cloudwatch::Builder::new()
             .cloudwatch_namespace("test-ns")
             .default_dimension("dimension", "default")
             .send_interval_secs(1)
             .storage_resolution(metrics_cloudwatch::Resolution::Second)
             .shutdown_signal(Box::pin(rx.map(|_| ())))
-            .init_future(metrics::set_boxed_recorder),
+            .init_future_mock(client.clone(), metrics::set_boxed_recorder),
     );
     let joinhandle = tokio::spawn(backend_fut);
     tokio::time::advance(Duration::from_millis(5)).await;


### PR DESCRIPTION
This hides the CloudWatch trait from end users, and enables them to easily customize the Cloudwatch client object before starting the server. The builder is also non-async right until the service is started, and we avoid some vtable overhead as we don't need `Box<dyn Cloudwatch>` anymore.