### PR TITLE
feat: Separate initialization of metrics_cloudwatch from driving it

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -17,15 +17,15 @@ async fn test_flush_on_shutdown() -> Result<(), Box<dyn Error>> {
 
     tokio::time::pause();
     let (tx, rx) = tokio::sync::oneshot::channel();
-    let backend_fut = Box::pin(
-        metrics_cloudwatch::Builder::new()
-            .cloudwatch_namespace("test-ns")
-            .default_dimension("dimension", "default")
-            .send_interval_secs(1)
-            .storage_resolution(metrics_cloudwatch::Resolution::Second)
-            .shutdown_signal(Box::pin(rx.map(|_| ())))
-            .init_future_mock(client.clone(), metrics::set_global_recorder),
-    );
+    let backend_fut = metrics_cloudwatch::Builder::new()
+        .cloudwatch_namespace("test-ns")
+        .default_dimension("dimension", "default")
+        .send_interval_secs(1)
+        .storage_resolution(metrics_cloudwatch::Resolution::Second)
+        .shutdown_signal(Box::pin(rx.map(|_| ())))
+        .init_future_mock(client.clone(), metrics::set_global_recorder)
+        .await?;
+
     let joinhandle = tokio::spawn(backend_fut);
     tokio::time::advance(Duration::from_millis(5)).await;
 
@@ -46,7 +46,7 @@ async fn test_flush_on_shutdown() -> Result<(), Box<dyn Error>> {
 
     // Send shutdown signal
     tx.send(()).unwrap();
-    joinhandle.await??;
+    joinhandle.await?;
 
     let actual = client.put_metric_data.lock().unwrap();
     assert_eq!(actual.len(), 1);


### PR DESCRIPTION
Currently it isn't possible to wait for set_global_recorder to be called before proceeding, making it possible to drop metrics that are sent between the call to `init` and `set_global_recorder` being called.

By separating the driver task like this one can call init first, waiting to send and metrics until it is done, and then spawn the future on a tokio task.